### PR TITLE
Move boot to end of list

### DIFF
--- a/VagrantConfig.yaml.example
+++ b/VagrantConfig.yaml.example
@@ -1,8 +1,3 @@
-boot:
-  ip: 192.168.65.50
-  cpus: 2
-  memory: 256
-  type: boot
 m1:
   ip: 192.168.65.90
   cpus: 2
@@ -66,3 +61,8 @@ p3:
   cpus: 2
   memory: 1024
   type: agent-public
+boot:
+  ip: 192.168.65.50
+  cpus: 2
+  memory: 256
+  type: boot


### PR DESCRIPTION
Better behavior if someone just prunes entries from the list and runs 'vagrant up'.
In the current ordering, boot starts first then complains that no masters are listed in genconf/config.yaml

(at least on the recent conf build that I'm trying with)
