### PR TITLE
Update box image to 0.5.0 to ensure recent Docker version.

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,7 +318,7 @@ There are several configurable options when deploying a cluster and installing D
 
 - `DCOS_BOX` - VirtualBox box image name (default: `mesosphere/dcos-centos-virtualbox`)
 - `DCOS_BOX_URL` - VirtualBox box image url or vagrant-cloud style image repo (default: `https://downloads.dcos.io/dcos-vagrant/metadata.json`)
-- `DCOS_BOX_VERSION` - VirtualBox box image version (default: `~> 0.4.1`)
+- `DCOS_BOX_VERSION` - VirtualBox box image version (default: `~> 0.5.0`)
 - `DCOS_MACHINE_CONFIG_PATH` - Path to virtual machine configuration manifest (default: `VagrantConfig.yaml`)
     - Must contain at least one `boot` type machine, one `master` type machine, and one `agent` or `agent-public` type machine.
 - `DCOS_CONFIG_PATH` - Path to DC/OS configuration template (default: `etc/config.yaml`)

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -24,7 +24,7 @@ class UserConfig
     c = self.new
     c.box                  = ENV.fetch('DCOS_BOX', 'mesosphere/dcos-centos-virtualbox')
     c.box_url              = ENV.fetch('DCOS_BOX_URL', 'https://downloads.dcos.io/dcos-vagrant/metadata.json')
-    c.box_version          = ENV.fetch('DCOS_BOX_VERSION', '~> 0.4.1')
+    c.box_version          = ENV.fetch('DCOS_BOX_VERSION', '~> 0.5.0')
     c.machine_config_path  = ENV.fetch('DCOS_MACHINE_CONFIG_PATH', 'VagrantConfig.yaml')
     c.config_path          = ENV.fetch('DCOS_CONFIG_PATH', 'etc/config.yaml')
     c.generate_config_path = ENV.fetch('DCOS_GENERATE_CONFIG_PATH', 'dcos_generate_config.sh')


### PR DESCRIPTION
Could we update the box image to 0.5.0 by default so that a more recent version of Docker is installed by default?