### PR TITLE
Only use 8.8.8.8 when a resolver is not set

### DIFF
--- a/lib/vagrant-dcos/provisioner.rb
+++ b/lib/vagrant-dcos/provisioner.rb
@@ -83,7 +83,9 @@ module VagrantPlugins
         when :aws
           gen_conf_config.resolvers = [ '169.254.169.253' ]
         else # :virtualbox
-          gen_conf_config.resolvers = [ '8.8.8.8' ]
+          if !gen_conf_config.resolvers
+            gen_conf_config.resolvers = [ '8.8.8.8' ]
+          end
         end
 
         @machine.ui.success 'Generating Configuration: ~/dcos/genconf/config.yaml'


### PR DESCRIPTION
My corporate network does not allow non corp dns servers and breaks . Setting a customer resolver in etc/config-x.y.yaml is not honored and defaults to 8.8.8.8 which breaks.