### PR TITLE
NixOS FIX: failed to create symbolic link

### DIFF
--- a/provision/bin/ca-certificates.sh
+++ b/provision/bin/ca-certificates.sh
@@ -6,4 +6,4 @@ set -o pipefail
 
 echo ">>> Installing Certificate Authorities"
 # DC/OS was compiled on ubuntu with certs in a different place!
-ln -s /etc/ssl/certs/ca-bundle.crt /etc/ssl/certs/ca-certificates.crt
+ln -sf /etc/ssl/certs/ca-bundle.crt /etc/ssl/certs/ca-certificates.crt


### PR DESCRIPTION
‘/etc/ssl/certs/ca-certificates.crt’: File exists
