### PR TITLE
Use the Google DNS servers as default

### DIFF
--- a/etc/config-1.7.yaml
+++ b/etc/config-1.7.yaml
@@ -6,7 +6,8 @@ master_discovery: static
 master_list:
 - 192.168.65.90
 resolvers:
-- 10.0.2.3
+- 8.8.8.8
+- 8.8.4.4
 superuser_username: admin
 superuser_password_hash: "$6$rounds=656000$123o/Qz.InhbkbsO$kn5IkpWm5CplEorQo7jG/27LkyDgWrml36lLxDtckZkCxu22uihAJ4DOJVVnNbsz/Y5MCK3B1InquE6E7Jmh30" # admin
 ssh_port: 22


### PR DESCRIPTION
In the current default config for 1.7, there's a non-public DNS resolver referenced (`10.0.2.3`). It would make more sense to have actually usable ones in the default config IMO.