### PR TITLE
Fix documentation that causes error.

### DIFF
--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -163,7 +163,7 @@ To test bleeding-edge Master releases of DC/OS it may be necessary to use the ma
 Specify which machines to deploy. For example (requires 5.5GB free memory):
 
 ```bash
-vagrant up m1 a1 p1 boot
+vagrant up boot m1 a1 p1
 ```
 
 Many permutations of machines are possible. See [Example Deployments](#example-deployments) for more options.
@@ -186,7 +186,7 @@ A minimal cluster supports launching small Marathon apps. Most other services wi
 Requires > 4.5GB free memory (using the example [VagrantConfig](./VagrantConfig.yaml.example)).
 
 ```bash
-vagrant up m1 a1 boot
+vagrant up boot m1 a1
 ```
 
 ## Small Cluster

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -196,7 +196,7 @@ A small cluster supports running tasks on multiple nodes.
 Requires > 7.25GB free memory (using the example [VagrantConfig](./VagrantConfig.yaml.example)).
 
 ```bash
-vagrant up m1 a1 a2 p1 boot
+vagrant up boot m1 a1 a2 p1
 ```
 
 ## Medium Cluster
@@ -206,7 +206,7 @@ A medium cluster supports the installation of a [minimally configured Cassandra]
 Requires > 10GB free memory (using the example [VagrantConfig](./VagrantConfig.yaml.example)).
 
 ```bash
-vagrant up m1 a1 a2 a3 a4 p1 boot
+vagrant up m1 boot a1 a2 a3 a4 p1
 ```
 
 ## Large Cluster
@@ -216,7 +216,7 @@ Requires > 17GB free memory (using the example [VagrantConfig](./VagrantConfig.y
 A large cluster supports master node fail over, multiple framework installs, and multiple public load balancers.
 
 ```bash
-vagrant up m1 m2 m3 a1 a2 a3 a4 a5 a6 p1 p2 p3 boot
+vagrant up boot m1 m2 m3 a1 a2 a3 a4 a5 a6 p1 p2 p3
 ```
 
 


### PR DESCRIPTION
Fixes request [Following documentation causes failed deployment.](https://dcosjira.atlassian.net/browse/SITE-29).

Updated each instance of _vagrant up_ example to place boot before other hosts.