### PR TITLE
Update docs: vagrant up order

### DIFF
--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -163,7 +163,7 @@ To test bleeding-edge Master releases of DC/OS it may be necessary to use the ma
 Specify which machines to deploy. For example (requires 5.5GB free memory):
 
 ```bash
-vagrant up m1 a1 p1 boot
+vagrant up boot m1 a1 p1
 ```
 
 Many permutations of machines are possible. See [Example Deployments](#example-deployments) for more options.
@@ -186,7 +186,7 @@ A minimal cluster supports launching small Marathon apps. Most other services wi
 Requires > 4.5GB free memory (using the example [VagrantConfig](./VagrantConfig.yaml.example)).
 
 ```bash
-vagrant up m1 a1 boot
+vagrant up boot m1 a1
 ```
 
 ## Small Cluster

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -163,7 +163,7 @@ To test bleeding-edge Master releases of DC/OS it may be necessary to use the ma
 Specify which machines to deploy. For example (requires 5.5GB free memory):
 
 ```bash
-vagrant up boot m1 a1 p1
+vagrant up m1 boot a1 p1
 ```
 
 Many permutations of machines are possible. See [Example Deployments](#example-deployments) for more options.
@@ -186,7 +186,7 @@ A minimal cluster supports launching small Marathon apps. Most other services wi
 Requires > 4.5GB free memory (using the example [VagrantConfig](./VagrantConfig.yaml.example)).
 
 ```bash
-vagrant up boot m1 a1
+vagrant up m1 boot a1
 ```
 
 ## Small Cluster
@@ -196,7 +196,7 @@ A small cluster supports running tasks on multiple nodes.
 Requires > 7.25GB free memory (using the example [VagrantConfig](./VagrantConfig.yaml.example)).
 
 ```bash
-vagrant up boot m1 a1 a2 p1
+vagrant up m1 boot a1 a2 p1
 ```
 
 ## Medium Cluster
@@ -216,7 +216,7 @@ Requires > 17GB free memory (using the example [VagrantConfig](./VagrantConfig.y
 A large cluster supports master node fail over, multiple framework installs, and multiple public load balancers.
 
 ```bash
-vagrant up boot m1 m2 m3 a1 a2 a3 a4 a5 a6 p1 p2 p3
+vagrant up m1 m2 m3 boot a1 a2 a3 a4 a5 a6 p1 p2 p3
 ```
 
 
@@ -234,7 +234,7 @@ Adding a node will not immediately change scheduled services by may allow pendin
 
 ```
 # Example initial cluster deploy
-vagrant up m1 a1 p1 boot
+vagrant up m1 boot a1 p1
 # Add a private agent node
 vagrant up a2
 # Add a public agent node
@@ -247,7 +247,7 @@ Removing an agent node will cause all tasks running on that node to be reschedul
 
 ```
 # Example initial cluster deploy
-vagrant up m1 a1 p1 boot
+vagrant up m1 boot a1 p1
 # Remove a private agent node
 vagrant destroy -f a1
 # Remove a public agent node

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -196,7 +196,7 @@ A small cluster supports running tasks on multiple nodes.
 Requires > 7.25GB free memory (using the example [VagrantConfig](./VagrantConfig.yaml.example)).
 
 ```bash
-vagrant up m1 a1 a2 p1 boot
+vagrant up boot m1 a1 a2 p1
 ```
 
 ## Medium Cluster
@@ -206,7 +206,7 @@ A medium cluster supports the installation of a [minimally configured Cassandra]
 Requires > 10GB free memory (using the example [VagrantConfig](./VagrantConfig.yaml.example)).
 
 ```bash
-vagrant up m1 a1 a2 a3 a4 p1 boot
+vagrant up m1 boot a1 a2 a3 a4 p1
 ```
 
 ## Large Cluster
@@ -216,7 +216,7 @@ Requires > 17GB free memory (using the example [VagrantConfig](./VagrantConfig.y
 A large cluster supports master node fail over, multiple framework installs, and multiple public load balancers.
 
 ```bash
-vagrant up m1 m2 m3 a1 a2 a3 a4 a5 a6 p1 p2 p3 boot
+vagrant up boot m1 m2 m3 a1 a2 a3 a4 a5 a6 p1 p2 p3
 ```
 
 


### PR DESCRIPTION
Vagrant up examples place boot at the end of the host list. This cases the agents to fail when attempting to install dcos agent.

This merge puts the boot host after the master(s) on all vagrant up examples.

Fixes: [Following documentation causes failed deployment.](https://dcosjira.atlassian.net/browse/SITE-29)