### PR TITLE
updated vagrant incompatiblity with virtualbox 5.1

### DIFF
--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -52,6 +52,7 @@ Known Incompatibilities:
 
 - Older versions of Vagrant are known to cause problems on Ubuntu 16
 - Older versions of VirtualBox are known to cause problems on Windows
+- [All versions of Vagrant are known to be incompatible with VirtualBox 5.1](troubleshooting.md#vagrant-up-fails-on-vagrant-184-with-virtualbox-51)
 
 ## Supported DC/OS Versions
 

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -52,7 +52,7 @@ Known Incompatibilities:
 
 - Older versions of Vagrant are known to cause problems on Ubuntu 16
 - Older versions of VirtualBox are known to cause problems on Windows
-- [All versions of Vagrant are known to be incompatible with VirtualBox 5.1](troubleshooting.md#vagrant-up-fails-on-vagrant-184-with-virtualbox-51)
+- [All versions of Vagrant are known to be incompatible with VirtualBox 5.1](/docs/troubleshooting.md#no-usable-default-provider)
 
 ## Supported DC/OS Versions
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -108,7 +108,7 @@ ulimit -n 1024
 
 **Solution**: Upgrade Vagrant to 1.8.4+ to fix an incompatibility with Ruby 2.3
 
-## Vagrant up fails on Vagrant 1.8.4 with VirtualBox 5.1
+## No Usable Default Provider
 
 **Problem**: The following error is returned when booting up a cluster via `vagrant up` using Vagrant
 1.8.4 and VirtualBox 5.1.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -107,3 +107,16 @@ ulimit -n 1024
 ```
 
 **Solution**: Upgrade Vagrant to 1.8.4+ to fix an incompatibility with Ruby 2.3
+
+## Vagrant up fails on Vagrant 1.8.4 with VirtualBox 5.1
+
+**Problem**: The following error is returned when booting up a cluster via `vagrant up` using Vagrant
+1.8.4 and VirtualBox 5.1.
+
+```
+No usable default provider could be found for your system.
+...
+```
+This is a known behavior and should be fixed with Vagrant 1.8.5. See [mitchellh/vagrant#7411](https://github.com/mitchellh/vagrant/issues/7411) for details.
+
+**Solution**: Using [VirtualBox 5.0](https://www.virtualbox.org/wiki/Download_Old_Builds_5_0) should resolve the incompatibility.


### PR DESCRIPTION
Updated known compatibilities list in deploy and linked to the troubleshooting doc.