### PR TITLE
Fix the ssh identity issue with Vagrant > 1.7.0

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -187,6 +187,9 @@ Vagrant.configure(2) do |config|
   config.hostmanager.manage_host = true
   config.hostmanager.ignore_private_ip = false
 
+  # Avoid random ssh key for demo purposes
+  config.ssh.insert_key = false
+  
   # Vagrant Plugin Configuration: vagrant-vbguest
   if Vagrant.has_plugin?('vagrant-vbguest')
     # enable auto update guest additions


### PR DESCRIPTION
The Vagrant demo spins up pretty easily, although I ran into an issue with the demo using the Vagrantfile as it is:

```
m1: Vagrant insecure key detected. Vagrant will automatically replace
m1: this with a newly generated keypair for better security.
m1: 
m1: Inserting generated public key within guest...
m1: Removing insecure key from the guest if it's present...
m1: Key inserted! Disconnecting and reconnecting using new SSH key...
m1: Warning: Authentication failure. Retrying...
m1: Warning: Authentication failure. Retrying...

```
See https://github.com/mitchellh/vagrant/pull/4707 for history in Vagrant's world. 

It seems like making this change would help people spin up this demo just a little bit easier.  If you'd prefer not to add it, I'll just close this out.