### PR TITLE
Clarify the DCOS_JAVA_ENABLED environment variable documentation

### DIFF
--- a/docs/configure.md
+++ b/docs/configure.md
@@ -60,7 +60,7 @@ There are several configurable options when deploying a cluster and installing D
     - `ssh_pull` - Use the "manual" DC/OS installation method (`dcos_install.sh`) with a pool of thread workers performing remote SHH installation.
     - `ssh_push` - Use the "automated" DC/OS installation method (`dcos_generate_config.sh --deploy`). WARNING: Does not (yet) support agent-public nodes!
     - `web` - Use the GUI DC/OS installation method (`dcos_generate_config.sh --web`). WARNING: Does not (yet) support agent-public nodes!
-- `DCOS_JAVA_ENABLED` - Boolean to install java on each agent (default: `false`).  If you set this to true, ensure that there is a jdk install file in your `provision` folder whose name matches `jre-*-linux-x64.*`
+- `DCOS_JAVA_ENABLED` - Boolean to install java on each agent (default: `false`).  If you set this to true, ensure that there is a JRE install file in your `provision` folder whose name matches `jre-*-linux-x64.*`
 - `DCOS_PRIVATE_REGISTRY` - Boolean to install an insecure [private Docker registry](/examples/private-registry.md) on the boot machine and configure the agents to allow it (default: `false`)
 - `DCOS_VAGRANT_MOUNT_METHOD` - One of the following methods (default: `virtualbox`):
     - `virtualbox` - Use cross-platform [VirtualBox shared folders](https://www.vagrantup.com/docs/synced-folders/virtualbox.html)

--- a/docs/configure.md
+++ b/docs/configure.md
@@ -60,7 +60,7 @@ There are several configurable options when deploying a cluster and installing D
     - `ssh_pull` - Use the "manual" DC/OS installation method (`dcos_install.sh`) with a pool of thread workers performing remote SHH installation.
     - `ssh_push` - Use the "automated" DC/OS installation method (`dcos_generate_config.sh --deploy`). WARNING: Does not (yet) support agent-public nodes!
     - `web` - Use the GUI DC/OS installation method (`dcos_generate_config.sh --web`). WARNING: Does not (yet) support agent-public nodes!
-- `DCOS_JAVA_ENABLED` - Boolean to install java on each agent (default: `false`)
+- `DCOS_JAVA_ENABLED` - Boolean to install java on each agent (default: `false`).  If you set this to true, ensure that there is a jdk install file in your `provision` folder whose name matches `jre-*-linux-x64.*`
 - `DCOS_PRIVATE_REGISTRY` - Boolean to install an insecure [private Docker registry](/examples/private-registry.md) on the boot machine and configure the agents to allow it (default: `false`)
 - `DCOS_VAGRANT_MOUNT_METHOD` - One of the following methods (default: `virtualbox`):
     - `virtualbox` - Use cross-platform [VirtualBox shared folders](https://www.vagrantup.com/docs/synced-folders/virtualbox.html)


### PR DESCRIPTION
Clarify the DCOS_JAVA_ENABLED environment variable documentation to mention that when set to true, a jdk install file must be placed in the provision folder.
