### PR TITLE
2 issues in provision/bin/type-boot.sh: typo of "ngnix"; stopped container clean up

### DIFF
--- a/provision/bin/type-boot.sh
+++ b/provision/bin/type-boot.sh
@@ -4,6 +4,9 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+echo "docker rm  to remove stopped container"
+docker rm $(docker ps -a -q) || echo "only rm stopped container, ignore rm failure"
+
 if [ "$(docker inspect -f '{{.State.Running}}' zookeeper-boot)" != "true" ]; then
   echo ">>> Starting zookeeper (for exhibitor bootstrap and quorum)"
   docker run -d --name=zookeeper-boot -p 2181:2181 -p 2888:2888 -p 3888:3888 --restart=always jplock/zookeeper
@@ -11,7 +14,7 @@ else
   echo ">>> Found zookeeper container running"
 fi
 
-if [ "$(docker inspect -f '{{.State.Running}}' nginx-boot)" != "true" ]; then
+if [ "$(docker inspect -f '{{.State.Running}}' ngnix-boot)" != "true" ]; then
   echo ">>> Starting nginx (for distributing bootstrap artifacts to cluster)"
   docker run -d --name=ngnix-boot -v /var/tmp/dcos:/usr/share/nginx/html -p 80:80 --restart=always nginx
 else


### PR DESCRIPTION
met 2 issues in provision/bin/type-boot.sh, when doing reload dcos, 
1, should remove stopped container first, otherwise, restart docker with same name would report error.
2, a typo of "nginx"