### PR TITLE
deploy.md: Add caveat about Vagrant 1.8.7

### DIFF
--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -49,6 +49,7 @@ The default guest OS box from [dcos-vagrant-box](https://github.com/dcos/dcos-va
 - [Vagrant 1.8.4 and prior are incompatible with VirtualBox 5.1](/docs/troubleshooting.md#no-usable-default-provider)
 - [Vagrant 1.8.5 has an SSH key permissions bug](/docs/troubleshooting.md#ssh-authentication-failure).
 - [Vagrant 1.8.6 has a network interface detection bug](/docs/troubleshooting.md#network-interface-configuration-failure).
+- [Vagrant 1.8.7 has a problem with downloading boxes](https://github.com/mitchellh/vagrant/issues/7969)
 
 ## Supported DC/OS Versions
 


### PR DESCRIPTION
[Vagrant 1.8.7 has a problem with downloading boxes](https://github.com/mitchellh/vagrant/issues/7969)