### PR TITLE
improve guest time sync with host

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -309,6 +309,9 @@ Vagrant.configure(2) do |config|
         v.customize ['modifyvm', :id, '--natdnshostresolver1', 'on']
 
         override.vm.network :private_network, ip: machine_type['ip']
+
+        # guest should sync time if more than 10s off host
+        v.customize [ "guestproperty", "set", :id, "/VirtualBox/GuestAdd/VBoxService/--timesync-set-threshold", 1000 ]
       end
 
       # Hack to remove loopback host alias that conflicts with vagrant-hostmanager


### PR DESCRIPTION
Time in VirtualBox guest VM's can fall out of sync when the host machine is
suspended and resumed.  You can see this by suspending a host for a few
minutes, wake it up, and compare host and guest clocks.

It seems VirtualBox will not take action until 20min of drift is seen.  This
change will reduce the threshold to 10s.  Details here:
http://stackoverflow.com/questions/19490652/how-to-sync-time-on-host-wake-up-within-virtualbox#19492466

The default value can't be seen but after setting, you can do this to see it:

    $ VBoxManage guestproperty get a1.dcos "/VirtualBox/GuestAdd/VBoxService/--timesync-set-threshold"
    Value: 10000

See corresponding commit in dcos-docker: https://github.com/dcos/dcos-docker/pull/24