### PR TITLE
Network restart to enable network interfaces

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -330,7 +330,10 @@ Vagrant.configure(2) do |config|
 
       # provision a shared SSH key (required by DC/OS SSH installer)
       machine.vm.provision :dcos_ssh, name: 'Shared SSH Key'
-
+	    
+      # restart network so private network interfaces are enabled
+      machine.vm.provision :shell, inline: "service network restart"
+	    
       machine.vm.provision :shell do |vm|
         vm.name = 'Certificate Authorities'
         vm.path = provision_script_path('ca-certificates')


### PR DESCRIPTION
After initial provision private network interfaces were not enabled unless you issue service network restart on all vm's  

I Added below to restart network so the private interfaces are enabled after provision and halt
machine.vm.provision :shell, inline: "service network restart"