### PR TITLE
set 3dt diag flag to `--diag`

### DIFF
--- a/provision/bin/install-postflight.sh
+++ b/provision/bin/install-postflight.sh
@@ -16,7 +16,7 @@ cat << 'EOF' > "/usr/local/sbin/dcos-postflight"
 TIMEOUT_SECONDS="${1:-900}"
 if [[ -e "/opt/mesosphere/bin/3dt" ]]; then
     # DC/OS >= 1.7
-    CMD="/opt/mesosphere/bin/3dt -diag"
+    CMD="/opt/mesosphere/bin/3dt --diag"
 elif [[ -e "/opt/mesosphere/bin/dcos-diagnostics.py" ]]; then
     # DC/OS <= 1.6
     CMD="/opt/mesosphere/bin/dcos-diagnostics.py"


### PR DESCRIPTION
with the latest refactor `-diag` will be unrecognizable by cobra and double
dash must be used instead. Earlier versions of 3dt should work fine with
either `-diag` or `--diag`.