### PR TITLE
use new binary for postflight

### DIFF
--- a/provision/bin/install-postflight.sh
+++ b/provision/bin/install-postflight.sh
@@ -11,12 +11,26 @@ echo ">>> Installing DC/OS Postflight: /usr/local/sbin/dcos-postflight"
 
 cat << 'EOF' > "/usr/local/sbin/dcos-postflight"
 #!/usr/bin/env bash
+shopt -s nullglob
+
 # Run the DC/OS diagnostic script for up to the specified number of seconds to ensure
 # we do not return ERROR on a cluster that hasn't fully achieved quorum.
 TIMEOUT_SECONDS="${1:-900}"
-if [[ -e "/opt/mesosphere/bin/3dt" ]]; then
-    # DC/OS >= 1.7
+if [[ -e "/opt/mesosphere/bin/dcos-diagnostics" ]]; then
+    # DC/OS >= 1.10
+    CMD="/opt/mesosphere/bin/dcos-diagnostics --diag"
+elif [[ -e "/opt/mesosphere/bin/3dt" ]]; then
+    # DC/OS <= 1.9
+    # 3dt --diag will complain about missing endpoints_config.json if not
+    # passed explicitly. This error is not influencing the diagnostics status.
+    # This is a bug, which has been fixed in DC/OS >= 1.10
     CMD="/opt/mesosphere/bin/3dt --diag"
+    cfg_files=( /opt/mesosphere/etc/dcos-3dt-endpoint-config*.json )
+    cfg_files+=( /opt/mesosphere/endpoints_config*.json )
+    cfg_files+=( /opt/mesosphere/etc/endpoints_config*.json )
+    if [ ${#cfg_files[@]} -gt 0 ]; then
+        CMD="${CMD} --endpoint-config=${cfg_files[0]}"
+    fi
 elif [[ -e "/opt/mesosphere/bin/dcos-diagnostics.py" ]]; then
     # DC/OS <= 1.6
     CMD="/opt/mesosphere/bin/dcos-diagnostics.py"


### PR DESCRIPTION
- in DC/OS >= 1.10 3dt binary has been renamed to dcos-diagnostics. The
  --diag remains the same.

- port over the endpoint config lookup from dcos-docker
  https://github.com/darkonie/dcos-docker/blob/master/Makefile#L482-L487

3dt with DC/OS <= 1.9 will complain about endpoint config if not passed
explicitly.

The endpoint config is used for collecting the logs from all nodes and the
only reason 3dt complains about endpoint config is because it is a bug.
The info message will not influence the exit code, so we should be good to just
ignore it.