### PR TITLE
Support download of installer using CA_CERT_BUNDLE

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -245,6 +245,9 @@ def download_installer_version(version, url, path, sha256Expected)
   UI.info "Destination: #{path}"
 
   options = {}
+  if ENV.has_key?('CURL_CA_BUNDLE')
+    options[:ca_cert] = ENV.fetch('CURL_CA_BUNDLE')
+  end
   if UI.level <= Log4r::INFO
     options[:ui] = Vagrant::UI::Colored.new
   end

--- a/docs/configure.md
+++ b/docs/configure.md
@@ -127,9 +127,10 @@ In DC/OS 1.8.5 proxies are allowed to be configured in `config.yaml`.
 
 Make sure that `no_proxy` includes all DC/OS Vagrant VM IPs and any local network addresses you want accessible to the cluster.
 
-Also make sure to update the user, password, and proxy address bellow.
+Also make sure to update the user, password, and proxy address below.
 
-While the example routes https through http, you probably want to use http -> http and https -> https, however this requires your proxy to use a valid SSL certificate.
+If the proxy intercepts SSL connections, set the environment variable `CURL_CA_BUNDLE` to the path of the proxy CA certificate to verify the installer download.
+This does not change the CA certificates used inside the cluster to verify secure connections.
 
 Example:
 

--- a/docs/configure.md
+++ b/docs/configure.md
@@ -67,6 +67,7 @@ There are several configurable options when deploying a cluster and installing D
 - `DCOS_VAGRANT_MOUNT_METHOD` - One of the following methods (default: `virtualbox`):
     - `virtualbox` - Use cross-platform [VirtualBox shared folders](https://www.vagrantup.com/docs/synced-folders/virtualbox.html)
     - `nfs` - Use faster [NFS shared folders](https://www.vagrantup.com/docs/synced-folders/nfs.html).
+- `CURL_CA_BUNDLE` - Path to an alternative CA certificate bundle to verify the installer download.
 
 Additional advanced configuration may be possible by modifying the Vagrantfile directly, but is not encouraged because the internal APIs may change at any time.
 


### PR DESCRIPTION
The installer script download within the dcos-vagrant Vagrantfile does not allow setting any CA certificate options. This prevents the Vagrantfile working behind an SSL-intercepting proxy.

This PR sets the `ca_cert` option from the `CURL_CA_BUNDLE` environment variable if it is set. This should support most scenarios where the default CA list is not correct.

This fixes the issue described in [DCOS_VAGRANT-59](https://jira.mesosphere.com/browse/DCOS_VAGRANT-59), except that it does not support setting the `insecure` option. The `insecure` option is a simpler but less secure solution to untrusted CA certificates. Use of `--insecure` can usually be handled better using `--ca_cert`.

As an alternative, we could also use the `SSL_CERT_FILE` environment variable used by Ruby `net/http`, but Vagrant uses cURL for downloads, so `CURL_CA_BUNDLE` seems like the appropriate variable to follow.