### PR TITLE
Rename py.test to pytest.

### DIFF
--- a/ci/test-integration.sh
+++ b/ci/test-integration.sh
@@ -18,5 +18,5 @@ vagrant ssh m1 -c " \
   export SLAVE_HOSTS='${SLAVE_HOSTS}' && \
   export PUBLIC_SLAVE_HOSTS='${PUBLIC_SLAVE_HOSTS}' && \
   cd /opt/mesosphere/active/dcos-integration-test && \
-  py.test -vv --junitxml=/vagrant/test-junit.xml -m 'not ccm' \
+  pytest -vv --junitxml=/vagrant/test-junit.xml -m 'not ccm' \
 "


### PR DESCRIPTION
pytest project recommends pytest entry point over py.test. (pytest-dev/pytest#1629, pytest-dev/pytest#1633)