### PR TITLE
assign each vm unique mac address

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -450,6 +450,8 @@ Vagrant.configure(2) do |config|
         v.customize ['modifyvm', :id, '--natdnsproxy1', 'off']
         # Host DNS resolution required to support host proxies and faster global DNS resolution
         v.customize ['modifyvm', :id, '--natdnshostresolver1', 'on']
+        # Assign unique mac address
+        v.customize ['modifyvm', :id, '--macaddress1', 'auto']
 
         override.vm.network :private_network, ip: machine_type['ip']
 


### PR DESCRIPTION
Today each vm ends up with the same mac address on the primary network interface.  Look for "macaddress1" changes in `vagrant up --debug` to see where this happens.  This ends up breaking some things I'm trying to install within the cluster, which require the primary mac to be unique per host.

The change asks VirtualBox to set the mac address for each host, using its default mechanism.