### PR TITLE
add master type node with bridge network supported for external access

### DIFF
--- a/VagrantConfig-1m-1a-1p-public.yaml
+++ b/VagrantConfig-1m-1a-1p-public.yaml
@@ -1,0 +1,27 @@
+m1:
+  publicip : 10.119.180.34
+  route: 10.119.180.254
+  ip: 192.168.65.90
+  cpus: 2
+  memory: 2048
+  type: master
+a1:
+  ip: 192.168.65.111
+  cpus: 4
+  memory: 6144
+  memory-reserved: 512
+  type: agent-private
+p1:
+  ip: 192.168.65.60
+  cpus: 2
+  memory: 1536
+  memory-reserved: 512
+  type: agent-public
+  aliases:
+  - spring.acme.org
+  - oinker.acme.org
+boot:
+  ip: 192.168.65.50
+  cpus: 2
+  memory: 1024
+  type: boot

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -460,11 +460,19 @@ Vagrant.configure(2) do |config|
         # Assign unique mac address
         v.customize ['modifyvm', :id, '--macaddress1', 'auto']
 
-        override.vm.network :private_network, ip: machine_type['ip']
+        # Configure master with another bridge network
+        if machine_type['type'] != "master"
+          override.vm.network "private_network", ip: machine_type['ip']
+        else
+          override.vm.network "public_network", ip: machine_type['publicip'], bridge: "em1"
+	  default_router = machine_type["route"]
+          config.vm.network "private_network", ip: machine_type['ip']
+        end
 
         # guest should sync time if more than 10s off host
         v.customize [ "guestproperty", "set", :id, "/VirtualBox/GuestAdd/VBoxService/--timesync-set-threshold", 1000 ]
       end
+
 
       # Hack to remove loopback host alias that conflicts with vagrant-hostmanager
       # https://jira.mesosphere.com/browse/DCOS_VAGRANT-15


### PR DESCRIPTION
The default VagrantConfig-1m-1a-1p.yaml configuration makes master node only can be accessed by the Host server and VMs, cannot access from the LAN co-located with Host server. Therefore, add the options in .yaml file for let master node can expose itself for the other LAN PCs accessing.