### PR TITLE
Fix for installing dc/os 1.11.0-rc4 using Vagrant.

### DIFF
--- a/dcos-versions.yaml
+++ b/dcos-versions.yaml
@@ -2,6 +2,10 @@
 # Get sha256: shasum -a 256 dcos_generate_config.sh
 latest: '1.10.4'
 versions:
+  '1.11.0-rc4':
+    channel: EarlyAccess
+    ref: '6c09a7e99d5c77b16a65cdb3fcbcdbe2a2406041'
+    sha256: '7f4d5182c4b22b61e1e2beacc17452c28bb82f6abb86cf46404c54b074b1214e'
   '1.10.4':
     channel: 'stable/1.10.4'
     ref: '2d45a8f9e277a60007f277f70f01d076c913a7fe'

--- a/etc/config-1.11.yaml
+++ b/etc/config-1.11.yaml
@@ -1,0 +1,16 @@
+---
+cluster_name: dcos-vagrant
+bootstrap_url: http://boot.dcos
+exhibitor_storage_backend: static
+master_discovery: static
+master_list:
+- 192.168.65.90
+resolvers:
+- 10.0.2.3
+superuser_username: admin
+superuser_password_hash: "$6$rounds=656000$123o/Qz.InhbkbsO$kn5IkpWm5CplEorQo7jG/27LkyDgWrml36lLxDtckZkCxu22uihAJ4DOJVVnNbsz/Y5MCK3B1InquE6E7Jmh30" # admin
+ssh_port: 22
+ssh_user: vagrant
+agent_list: []
+platform: vagrant-virtualbox
+check_time: false


### PR DESCRIPTION
Currently the Vagrant configuration for 1.11.0-rc4 is missing in the `dcos-versions.yaml`. Also, the `/etc/config-1.11.yaml` isnt present, this requires downloading the package and providing the config file for every person who would clone the repo.  
This PR does the folllowing. 
- Add stanza for DC/OS 1.11.0-rc4
- Add config file for the release. 